### PR TITLE
Fix: honor $VISUAL/$EDITOR with robust fallbacks and error on editor launch failure to prevent skipping straight to reload

### DIFF
--- a/internal/shortcuts/yaml_file.go
+++ b/internal/shortcuts/yaml_file.go
@@ -6,7 +6,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/swarupdonepudi/karayaml/internal/defaulteditor"
 	"os"
-	"os/exec"
 	"path/filepath"
 )
 
@@ -29,11 +28,13 @@ func editYaml() error {
 	for {
 		duplicates := make([]string, 0)
 
-		cmd := exec.Command(defaulteditor.DefaultEditor, "--wait", configFile)
+		cmd := defaulteditor.NewEditorCommand(configFile)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Stdin = os.Stdin
-		cmd.Run()
+		if err := cmd.Run(); err != nil {
+			return errors.Wrapf(err, "failed to launch editor")
+		}
 
 		appShortcuts, err := load()
 		if err != nil {


### PR DESCRIPTION
#### What was the issue?

Running `karayaml edit` on systems where the VS Code CLI (`code`) isn’t installed or not on PATH would silently fail to open the editor and immediately proceed to the reload step. This felt like the command “skipped the editor.”

#### Root cause

- The editor was hard-coded to `code` and the result of `cmd.Run()` was ignored. If `code` was missing, the error was swallowed and the flow continued.
- The implementation didn’t honor `$VISUAL` / `$EDITOR` despite the site claiming it does.

#### What changed
- Editor resolution made environment-aware with sensible fallbacks, and editor launch failure now stops the flow with a clear error.

- Added `defaulteditor.NewEditorCommand(filePath)`:
  - Resolution order:
    - `$VISUAL`
    - `$EDITOR`
    - VS Code `code --wait` (if available)
    - macOS TextEdit via `open -W -t` (blocks until closed)
    - Final fallback: `vi`
  - If the chosen editor is `code`, `--wait` is injected when missing so we always block until the file is closed.
  - Supports explicit paths or PATH-resolved binaries.

- Switched `editYaml()` to use the new resolver and to return the error if the editor cannot be launched:
  - Replaced `exec.Command(defaulteditor.DefaultEditor, "--wait", ...)` with `defaulteditor.NewEditorCommand(...)`.
  - Check `cmd.Run()` and return a wrapped error instead of ignoring it.

- Minor cleanup: removed the unused `os/exec` import from `yaml_file.go`.

#### Files touched
- `internal/defaulteditor/default_editor.go`: replaced constant with `NewEditorCommand(filePath)` and implemented resolution/fallback logic.
- `internal/shortcuts/yaml_file.go`: use `NewEditorCommand`, check `cmd.Run()` error; removed unused import.

#### Behavior before vs after
- Before:
  - Always tried `code --wait`.
  - If `code` wasn’t found, the error was ignored and the command proceeded to reload.
- After:
  - Uses `$VISUAL` or `$EDITOR` if set (injects `--wait` for VS Code).
  - Falls back to `code --wait` if available.
  - On macOS, falls back to `open -W -t` (TextEdit) which blocks until closed.
  - Final fallback is `vi`.
  - If the editor cannot be launched, the command fails with an actionable error message instead of silently continuing.

#### Verification
- Built successfully via `go build ./...` and `make build`.
- Manual checks:
  - With `$EDITOR` unset and `code` absent: opens TextEdit on macOS and blocks until closed.
  - With `$EDITOR=nano`: opens nano and blocks.
  - With `$VISUAL=code`: adds `--wait` automatically.
  - With `code` available and no env vars: uses `code --wait`.

#### Notes and alignment
- This change aligns the implementation with the site’s stated behavior that `karayaml edit` uses `$EDITOR` (or defaults to VS Code).
- Backward compatible for users who already had `code` installed; they keep the same flow but with better error messaging if launch fails.

#### Release notes
- `karayaml edit` now respects `$VISUAL`/`$EDITOR`, has macOS and terminal fallbacks, and fails fast with a clear error when the editor cannot be launched instead of skipping straight to reload.