### PR TITLE
Add F-key support, persist mappings to ~/.kara.yaml, and grouped sorted listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ deps:
 	go mod tidy
 
 .PHONY: build_darwin
-build_darwin: vet
+build_darwin: vet fmt
 	GOOS=darwin ${build_cmd} -o ${build_dir}/${name}-darwin .
 
 .PHONY: build
 build: ${build_dir}/${name}
 
-${build_dir}/${name}: deps vet
+${build_dir}/${name}: deps vet fmt
 	GOOS=darwin GOARCH=amd64 ${build_cmd} -o ${build_dir}/${name}-darwin-amd64 .
 	GOOS=darwin GOARCH=arm64 ${build_cmd} -o ${build_dir}/${name}-darwin-arm64 .
 

--- a/cmd/karayaml/root/initialize.go
+++ b/cmd/karayaml/root/initialize.go
@@ -3,8 +3,8 @@ package root
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-    "github.com/swarupdonepudi/karayaml/internal/karabinerconfig"
-    "github.com/swarupdonepudi/karayaml/internal/shortcuts"
+	"github.com/swarupdonepudi/karayaml/internal/karabinerconfig"
+	"github.com/swarupdonepudi/karayaml/internal/shortcuts"
 )
 
 var Init = &cobra.Command{
@@ -14,22 +14,22 @@ var Init = &cobra.Command{
 }
 
 func initHandler(cmd *cobra.Command, args []string) {
-    if err := karabinerconfig.Setup(); err != nil {
-        log.Fatalf("failed to setup karabiner config")
-        return
-    }
+	if err := karabinerconfig.Setup(); err != nil {
+		log.Fatalf("failed to setup karabiner config")
+		return
+	}
 
-    if created, err := shortcuts.EnsureDefaultShortcuts(); err != nil {
-        log.Fatalf("failed to ensure default shortcuts: %v", err)
-        return
-    } else if created {
-        log.Info("created default shortcuts for Safari (s) and Mail (m)")
-    }
+	if created, err := shortcuts.EnsureDefaultShortcuts(); err != nil {
+		log.Fatalf("failed to ensure default shortcuts: %v", err)
+		return
+	} else if created {
+		log.Info("created default shortcuts for Safari (s) and Mail (m)")
+	}
 
-    if err := shortcuts.Reload(); err != nil {
-        log.Fatalf("failed to reload shortcuts: %v", err)
-        return
-    }
+	if err := shortcuts.Reload(); err != nil {
+		log.Fatalf("failed to reload shortcuts: %v", err)
+		return
+	}
 
-    log.Info("initialized karabiner config and shortcuts")
+	log.Info("initialized karabiner config and shortcuts")
 }

--- a/cmd/karayaml/root/map.go
+++ b/cmd/karayaml/root/map.go
@@ -4,6 +4,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/swarupdonepudi/karayaml/internal/shortcuts"
+	"strings"
 )
 
 var Map = &cobra.Command{
@@ -14,11 +15,11 @@ var Map = &cobra.Command{
 }
 
 func mapHandler(cmd *cobra.Command, args []string) {
-	key := args[0]
+	key := strings.ToLower(args[0])
 	file := args[1]
 
-	if len(key) != 1 {
-		log.Fatalf("key must only be one character")
+	if !shortcuts.IsValidKeyBoardKey(key) {
+		log.Fatalf("invalid key: must be one of the supported keys; see internal/shortcuts/key_board_key.go")
 		return
 	}
 
@@ -26,5 +27,3 @@ func mapHandler(cmd *cobra.Command, args []string) {
 		log.Fatalf("%v", err)
 	}
 }
-
-

--- a/internal/karabinerconfig/config.go
+++ b/internal/karabinerconfig/config.go
@@ -21,7 +21,7 @@ func Setup() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get path of the config file")
 	}
-    if err := os.MkdirAll(filepath.Dir(configFile), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configFile), 0755); err != nil {
 		return errors.Wrapf(err, "failed to ensure %s dir", filepath.Dir(configFile))
 	}
 	c, err := GetDefault()

--- a/internal/shortcuts/add.go
+++ b/internal/shortcuts/add.go
@@ -6,21 +6,26 @@ import (
 
 // Add another shortcut to existing shortcuts, and then reloads the karabiner config.
 func Add(key, file string) error {
-    // Ensure shortcuts config exists; start with empty if missing
-    shortcuts := make([]*FileOpenShortcut, 0)
-    if cfgPath, err := getShortcutConfigFilePath(); err == nil {
-        if IsFileExists(cfgPath) {
-            loaded, loadErr := load()
-            if loadErr != nil {
-                return errors.Wrapf(loadErr, "failed to get list of shortcuts from config file")
-            }
-            shortcuts = loaded
-        }
-    }
+	// Ensure shortcuts config exists; start with empty if missing
+	shortcuts := make([]*FileOpenShortcut, 0)
+	if cfgPath, err := getShortcutConfigFilePath(); err == nil {
+		if IsFileExists(cfgPath) {
+			loaded, loadErr := load()
+			if loadErr != nil {
+				return errors.Wrapf(loadErr, "failed to get list of shortcuts from config file")
+			}
+			shortcuts = loaded
+		}
+	}
 	shortcuts = append(shortcuts, &FileOpenShortcut{
 		Key:  KeyBoardKey(key),
 		File: file,
 	})
+	// First write to the YAML config so ~/.kara.yaml reflects the new mapping
+	if err := Write(shortcuts); err != nil {
+		return errors.Wrap(err, "failed to write shortcuts to yaml config")
+	}
+	// Then apply to Karabiner config
 	if err := save(shortcuts); err != nil {
 		return errors.Wrap(err, "failed to save list of shortcuts")
 	}

--- a/internal/shortcuts/edit.go
+++ b/internal/shortcuts/edit.go
@@ -13,6 +13,10 @@ func Edit() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get list of shortcuts from config file")
 	}
+	// Persist sorted YAML while preserving duplicate key order
+	if err := Write(shortcuts); err != nil {
+		return errors.Wrapf(err, "failed to write sorted shortcuts to yaml config")
+	}
 	if err := save(shortcuts); err != nil {
 		return errors.Wrap(err, "failed to save list of shortcuts")
 	}

--- a/internal/shortcuts/key_board_key.go
+++ b/internal/shortcuts/key_board_key.go
@@ -1,5 +1,7 @@
 package shortcuts
 
+import "strings"
+
 type KeyBoardKey string
 
 const (
@@ -54,3 +56,20 @@ const (
 	NumberTen   KeyBoardKey = "10"
 	SemiColon   KeyBoardKey = ";" //does not work as hot key with karabiner
 )
+
+var AllowedKeyBoardKeys = []KeyBoardKey{
+	F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
+	A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+	NumberZero, NumberOne, NumberTwo, NumberThree, NumberFour, NumberFive, NumberSix, NumberSeven, NumberEight, NumberNine, NumberTen,
+	SemiColon,
+}
+
+func IsValidKeyBoardKey(key string) bool {
+	key = strings.ToLower(key)
+	for _, k := range AllowedKeyBoardKeys {
+		if string(k) == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/shortcuts/key_sort.go
+++ b/internal/shortcuts/key_sort.go
@@ -1,0 +1,65 @@
+package shortcuts
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// classifyKey returns a category rank, a numeric value rank (when available),
+// and the normalized key string for lexicographic fallback.
+// Category order: 0=function keys, 1=numbers, 2=letters/others.
+func classifyKey(key string) (int, int, string) {
+	k := strings.ToLower(key)
+	// Function keys: f1..f12
+	if strings.HasPrefix(k, "f") {
+		if n, err := strconv.Atoi(strings.TrimPrefix(k, "f")); err == nil {
+			return 0, n, k
+		}
+	}
+	// Numbers: 0..10
+	if n, err := strconv.Atoi(k); err == nil {
+		return 1, n, k
+	}
+	// Letters/others
+	return 2, 0, k
+}
+
+// sortHotkeyStringsStable sorts keys in-place by function keys, then numbers, then letters.
+func sortHotkeyStringsStable(keys []string) {
+	sort.SliceStable(keys, func(i, j int) bool {
+		ci, vi, si := classifyKey(keys[i])
+		cj, vj, sj := classifyKey(keys[j])
+		if ci != cj {
+			return ci < cj
+		}
+		// For function keys and numbers, sort by numeric value
+		if ci == 0 || ci == 1 {
+			if vi != vj {
+				return vi < vj
+			}
+			return si < sj
+		}
+		// For letters/others, sort lexicographically
+		return si < sj
+	})
+}
+
+// sortShortcutsStable sorts shortcuts in-place using the same ordering. It is
+// stable, so entries with identical keys preserve their original relative order.
+func sortShortcutsStable(shortcuts []*FileOpenShortcut) {
+	sort.SliceStable(shortcuts, func(i, j int) bool {
+		ci, vi, si := classifyKey(string(shortcuts[i].Key))
+		cj, vj, sj := classifyKey(string(shortcuts[j].Key))
+		if ci != cj {
+			return ci < cj
+		}
+		if ci == 0 || ci == 1 {
+			if vi != vj {
+				return vi < vj
+			}
+			return si < sj
+		}
+		return si < sj
+	})
+}

--- a/internal/shortcuts/list.go
+++ b/internal/shortcuts/list.go
@@ -4,31 +4,62 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/pkg/errors"
 	"os"
-	"sort"
 )
 
-// List returns a map of keyboard shortcuts
-func List() (map[KeyBoardKey]*FileOpenShortcut, error) {
+// List returns the list of keyboard shortcuts as they exist in the YAML file.
+// The order returned reflects the file order (prior to any display sorting).
+func List() ([]*FileOpenShortcut, error) {
 	shortcuts, err := load()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get keyboard shortcuts")
 	}
-	return convertToMap(shortcuts), nil
+	return shortcuts, nil
 }
 
-// PrintList prints the provided shortcuts map to the console
-func PrintList(shortcuts map[KeyBoardKey]*FileOpenShortcut) {
-	header := table.Row{"key", "app path"}
-	rows := make([]table.Row, 0)
-	hotkeys := make([]string, 0)
-	for k, _ := range shortcuts {
-		hotkeys = append(hotkeys, string(k))
+// PrintList prints the provided shortcuts to the console as three tables:
+// Function Keys, Numbers, and Letters. Within each category, entries are
+// ordered stably so duplicate keys preserve their YAML order.
+func PrintList(shortcuts []*FileOpenShortcut) {
+	ordered := make([]*FileOpenShortcut, len(shortcuts))
+	copy(ordered, shortcuts)
+	sortShortcutsStable(ordered)
+
+	functionKeys := make([]*FileOpenShortcut, 0)
+	numbers := make([]*FileOpenShortcut, 0)
+	letters := make([]*FileOpenShortcut, 0)
+	for _, s := range ordered {
+		c, _, _ := classifyKey(string(s.Key))
+		switch c {
+		case 0:
+			functionKeys = append(functionKeys, s)
+		case 1:
+			numbers = append(numbers, s)
+		default:
+			letters = append(letters, s)
+		}
 	}
-	sort.Strings(hotkeys)
-	for _, r := range hotkeys {
-		rows = append(rows, table.Row{shortcuts[KeyBoardKey(r)].Key, shortcuts[KeyBoardKey(r)].File})
+
+	if len(functionKeys) > 0 {
+		rows := make([]table.Row, 0, len(functionKeys))
+		for _, s := range functionKeys {
+			rows = append(rows, table.Row{s.Key, s.File})
+		}
+		printTableWithTitle("Function Keys", rows)
 	}
-	printTable(header, rows)
+	if len(numbers) > 0 {
+		rows := make([]table.Row, 0, len(numbers))
+		for _, s := range numbers {
+			rows = append(rows, table.Row{s.Key, s.File})
+		}
+		printTableWithTitle("Numbers", rows)
+	}
+	if len(letters) > 0 {
+		rows := make([]table.Row, 0, len(letters))
+		for _, s := range letters {
+			rows = append(rows, table.Row{s.Key, s.File})
+		}
+		printTableWithTitle("Letters", rows)
+	}
 }
 
 func printTable(header table.Row, rows []table.Row) {
@@ -38,13 +69,14 @@ func printTable(header table.Row, rows []table.Row) {
 	println("")
 }
 
-// convertToMap converts the provided shortcuts into a map
-func convertToMap(shortcuts []*FileOpenShortcut) map[KeyBoardKey]*FileOpenShortcut {
-	shortcutsMap := make(map[KeyBoardKey]*FileOpenShortcut, 0)
-	for _, s := range shortcuts {
-		shortcutsMap[s.Key] = s
+func printTableWithTitle(title string, rows []table.Row) {
+	println("")
+	t := getDefaultTableWriter(nil, rows)
+	if title != "" {
+		t.SetTitle(title)
 	}
-	return shortcutsMap
+	t.Render()
+	println("")
 }
 
 func getDefaultTableWriter(header table.Row, rows []table.Row) table.Writer {

--- a/internal/shortcuts/save.go
+++ b/internal/shortcuts/save.go
@@ -64,3 +64,14 @@ func Reload() error {
 	}
 	return nil
 }
+
+// convertToMap converts the provided shortcuts into a map keyed by KeyBoardKey.
+// When the same key appears multiple times, the last occurrence wins for
+// Karabiner rule generation.
+func convertToMap(shortcuts []*FileOpenShortcut) map[KeyBoardKey]*FileOpenShortcut {
+	shortcutsMap := make(map[KeyBoardKey]*FileOpenShortcut, 0)
+	for _, s := range shortcuts {
+		shortcutsMap[s.Key] = s
+	}
+	return shortcutsMap
+}

--- a/internal/shortcuts/yaml_file.go
+++ b/internal/shortcuts/yaml_file.go
@@ -19,12 +19,12 @@ func editYaml() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get shortcut config file path")
 	}
-    // Ensure file exists with an empty list if missing
-    if !IsFileExists(configFile) {
-        if err := Write([]*FileOpenShortcut{}); err != nil {
-            return errors.Wrapf(err, "failed to initialize shortcut config file")
-        }
-    }
+	// Ensure file exists with an empty list if missing
+	if !IsFileExists(configFile) {
+		if err := Write([]*FileOpenShortcut{}); err != nil {
+			return errors.Wrapf(err, "failed to initialize shortcut config file")
+		}
+	}
 	for {
 		duplicates := make([]string, 0)
 
@@ -69,8 +69,10 @@ func Write(shortcuts []*FileOpenShortcut) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get config file path")
 	}
+	// Sort for consistent YAML ordering while preserving duplicate key order
+	sortShortcutsStable(shortcuts)
 	if !IsDirExists(filepath.Dir(shortcutConfigFilePath)) {
-        if err := os.MkdirAll(filepath.Dir(shortcutConfigFilePath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(shortcutConfigFilePath), 0755); err != nil {
 			return errors.Wrapf(err, "failed to create %s dir", filepath.Dir(shortcutConfigFilePath))
 		}
 	}
@@ -78,7 +80,7 @@ func Write(shortcuts []*FileOpenShortcut) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to initialize")
 	}
-    if err := os.WriteFile(shortcutConfigFilePath, defaultShortcutsYamlBytes, 0644); err != nil {
+	if err := os.WriteFile(shortcutConfigFilePath, defaultShortcutsYamlBytes, 0644); err != nil {
 		return errors.Wrapf(err, "failed to write %s file", shortcutConfigFilePath)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Accept F1–F12 and single-character keys; centralized validation via shortcuts.IsValidKeyBoardKey using AllowedKeyBoardKeys.
- karayaml map now persists new mappings to ~/.kara.yaml and then applies them to Karabiner.
- List output is grouped into three tables (Function Keys, Numbers, Letters), stably sorted within each group; duplicate keys preserve YAML order.
- YAML is written in the same stable order (on map and after edit).

## Changes
- cmd/karayaml/root/map.go: use shortcuts.IsValidKeyBoardKey; normalize key; improved error messaging.
- internal/shortcuts/key_board_key.go: Added AllowedKeyBoardKeys and IsValidKeyBoardKey.
- internal/shortcuts/key_sort.go: Added classifyKey, sortHotkeyStringsStable, sortShortcutsStable.
- internal/shortcuts/list.go: List() now returns []*FileOpenShortcut; PrintList() outputs three titled tables without headers.
- internal/shortcuts/yaml_file.go: Write() sorts shortcuts before marshaling; Edit() rewrites sorted YAML after user edits.
- internal/shortcuts/add.go: Write() YAML before applying to Karabiner.
- internal/shortcuts/save.go: Local convertToMap retained; last duplicate key wins for Karabiner rules.

## Behavior
- karayaml map f4 "<App>" updates ~/.kara.yaml and Karabiner.
- karayaml list prints three tables: Function Keys, Numbers, Letters; no header rows; ordered F-keys first, then numbers, then letters; duplicates keep YAML order.

## Test Plan
- make build
- karayaml map f4 "<AppPath>" → verify ~/.kara.yaml updated and Karabiner rules written.
- karayaml list → verify grouped tables and ordering.
- Add duplicate entries for the same key in YAML → verify both are listed in original order; last wins in Karabiner.

## Notes
- CLI behavior preserved; internal API adjusted (List() now returns a slice).