### PR TITLE
add AppleScript wait script and Make target; update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ test:
 run: build
 	${build_dir}/${name}
 
+.PHONY: textedit-test
+textedit-test:
+	VISUAL= EDITOR="osascript ${CURDIR}/scripts/textedit_wait.applescript" go run ./main.go edit
+
+.PHONY: text
+text: textedit-test
+
 .PHONY: vet
 vet:
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ make build          # Darwin ARM64 and AMD64 binaries in ./build
 
 ---
 
+## Make targets
+
+### TextEdit editor test (bypass VS Code)
+
+Use this to test the edit flow with macOS TextEdit and ensure the CLI waits for the document window to close (Cmd+W) instead of requiring you to quit TextEdit:
+
+```bash
+make text
+# or the explicit target name
+make textedit-test
+```
+
+This target runs the `edit` command with the environment configured to force TextEdit:
+
+- **VISUAL** is cleared and **EDITOR** is set to run the AppleScript at `scripts/textedit_wait.applescript` via `osascript`.
+- Works on macOS only. Close the TextEdit window to let the CLI continue and reload configuration.
+
+---
+
 ## Contributing
 
 Issues and PRs are welcome. Please:

--- a/scripts/textedit_wait.applescript
+++ b/scripts/textedit_wait.applescript
@@ -1,0 +1,12 @@
+on run argv
+  set thePath to POSIX file (item 1 of argv)
+  tell application "TextEdit"
+    activate
+    set theDoc to open thePath
+    repeat while (exists theDoc)
+      delay 0.2
+    end repeat
+  end tell
+end run
+
+


### PR DESCRIPTION
- **Why**: Enable easy testing of the TextEdit flow that waits for the document window to close (Cmd+W), bypassing VS Code even when `code` is available. Mirrors the fallback logic in `internal/defaulteditor/default_editor.go`.
- **What**:
  - Added `scripts/textedit_wait.applescript` that opens the file in TextEdit and blocks until the specific window closes.
  - Added Make targets:
    - `textedit-test`: runs `go run ./main.go edit` with `VISUAL=` and `EDITOR="osascript $(CURDIR)/scripts/textedit_wait.applescript"`.
    - `text`: alias for `textedit-test`.
  - Updated `README.md` with usage instructions.

- **How to test**
  - Run:
    ```bash
    make text
    # or
    make textedit-test
    ```
  - TextEdit should open `~/.kara.yaml`. Save, then close the window (Cmd+W). The CLI should resume, re-parse YAML, and continue without requiring you to quit TextEdit.
  - Optional chaining:
    ```bash
    make text test
    ```

- **Notes**
  - macOS-only behavior; uses `osascript` to run the AppleScript.
  - No changes to runtime behavior for end users; this is a dev/test convenience.

- **Files**
  - `scripts/textedit_wait.applescript` (new)
  - `Makefile` (add `textedit-test` and `text`)
  - `README.md` (document new target)