### PR TITLE
feat(cmd): add command aliases and filter command with key/app subcommands

### DIFF
--- a/.cursor/rules/commit-karayaml-changes.mdc
+++ b/.cursor/rules/commit-karayaml-changes.mdc
@@ -1,0 +1,249 @@
+---
+description: Action rule to commit karayaml changes with appropriate conventional commit messages
+alwaysApply: false
+---
+
+# Rule: Commit KaraYaml Changes
+
+## Purpose
+
+When triggered, create a Git commit with an appropriate commit message following Conventional Commits format, based on the current conversation context and file changes.
+
+## Rule Type
+
+**Action Rule** - Executes git commit operations
+
+## When to Use
+
+- When user explicitly asks to commit changes
+- After completing a feature or fix that's ready to be committed
+- When wrapping up a development session
+
+## Commit Message Format
+
+Follow Conventional Commits format:
+
+```
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footer]
+```
+
+### Types
+
+Use these commit types:
+- `feat`: New feature
+- `fix`: Bug fix
+- `refactor`: Code refactoring (no functional changes)
+- `docs`: Documentation only changes
+- `test`: Adding or updating tests
+- `chore`: Build process, tooling, dependencies
+- `perf`: Performance improvements
+- `style`: Code style changes (formatting, no logic changes)
+- `ci`: CI/CD changes
+- `revert`: Reverting previous commits
+
+### Scope
+
+Determine scope from the affected files/components in the karayaml repository:
+
+#### Core Commands
+- `cmd`: CLI commands and command handlers
+- `cmd/root`: Root command implementation (e.g., `cmd/karayaml/root/*.go`)
+
+#### Internal Packages
+- `internal/shortcuts`: Shortcut loading, listing, searching, filtering, display
+- `internal/karabinerconfig`: Karabiner-Elements configuration generation
+- `internal/defaulteditor`: Default editor detection
+- `internal/upgrade`: CLI self-upgrade logic
+
+#### Site
+- `site`: Landing page website
+
+#### Build & Tooling
+- `build`: Build system, Makefile, and script changes
+- `release`: GoReleaser configuration
+- `deps`: Dependency updates (`go.mod`, `go.sum`)
+
+#### Documentation
+- `docs`: Documentation changes
+- `readme`: README updates
+
+#### Cross-cutting
+- If multiple areas: Use broader scope or omit scope
+- For repo-wide changes: Use `repo` or omit scope
+
+### Subject
+
+- Use imperative mood ("add" not "added" or "adds")
+- No period at the end
+- Keep under 72 characters
+- Be specific but concise
+
+### Body (Optional)
+
+Add detailed body when:
+- The change is complex and needs explanation
+- Multiple related changes are included
+- There are breaking changes
+- Context would help future developers understand "why"
+
+Body guidelines:
+- Wrap at 72 characters
+- Explain what and why, not how
+- Use bullet points for multiple items
+- Reference issues/tickets if applicable
+
+### Footer (Optional)
+
+Include footer for:
+- `BREAKING CHANGE:` for breaking changes
+- `Closes #123` or `Fixes #123` for issue references
+- Co-authored-by for pair programming
+
+## Execution Steps
+
+1. **Analyze Changes**
+   - Check `git status` to see modified files
+   - Review the conversation context to understand what was changed
+   - Identify the type and scope of changes
+
+2. **Determine Commit Type and Scope**
+   - Map file changes to appropriate type
+   - Determine most relevant scope from file paths
+   - Consider which part(s) of karayaml are affected
+
+3. **Craft Commit Message**
+   - Write concise subject line (< 72 chars)
+   - Decide if detailed body is needed based on:
+     - Complexity of changes
+     - Number of related changes
+     - Need for future context
+   - Add footer if there are breaking changes or issue references
+
+4. **Create Commit**
+   - Stage all changes with `git add -A`
+   - Commit with the crafted message using `git commit -m "subject" [-m "body"]`
+   - Use `-m` flag multiple times for subject + body, or use multiline format
+
+## Examples
+
+### Simple Feature Addition
+
+```bash
+git commit -m "feat(cmd/root): add search alias for find command"
+```
+
+### Bug Fix with Context
+
+```bash
+git commit -m "fix(internal/shortcuts): handle empty YAML file without error" \
+  -m "The shortcut loader was returning an unmarshal error when the
+~/.kara.yaml file existed but was empty. This commit adds a check
+for empty content before attempting to parse."
+```
+
+### Command Enhancement
+
+```bash
+git commit -m "feat(cmd/root): add filter command with key and app subcommands" \
+  -m "Implement filter-key and filter-app subcommands under a new filter
+parent command. Both support fuzzy substring matching by default and
+exact matching via --exact flag."
+```
+
+### Refactoring with Multiple Files
+
+```bash
+git commit -m "refactor(internal/shortcuts): extract key classification into separate module" \
+  -m "- Move classifyKey() and sorting helpers to key_sort.go
+- Add sortShortcutsStable() for consistent display ordering
+- Update list and find functions to use new helpers
+- No functional changes to external behavior"
+```
+
+### Breaking Change
+
+```bash
+git commit -m "feat(internal/karabinerconfig)!: change shortcut key format in YAML" \
+  -m "BREAKING CHANGE: Shortcut keys in ~/.kara.yaml now use lowercase
+only. Existing configs with uppercase keys must be converted.
+
+This simplifies key validation and matching across all commands."
+```
+
+### Documentation Update
+
+```bash
+git commit -m "docs(readme): add installation instructions for Homebrew"
+```
+
+### Site Update
+
+```bash
+git commit -m "feat(site): add features comparison section to landing page"
+```
+
+### Build System
+
+```bash
+git commit -m "chore(build): update GoReleaser config to version 2 format"
+```
+
+## Command Patterns
+
+For simple commits:
+```bash
+git add -A && git commit -m "<type>(<scope>): <subject>"
+```
+
+For commits with body:
+```bash
+git add -A && git commit -m "<type>(<scope>): <subject>" -m "<body>"
+```
+
+For commits with multi-paragraph body:
+```bash
+git add -A
+git commit -m "<type>(<scope>): <subject>" \
+  -m "<paragraph 1>" \
+  -m "" \
+  -m "<paragraph 2>"
+```
+
+## Important Notes
+
+- **Always run in karayaml workspace**: `~/scm/github.com/swarupdonepudi/karayaml`
+- **Don't commit without reviewing**: Show the proposed commit message to the user before executing if the changes are significant
+- **Stage selectively if needed**: If only some changes should be committed, stage specific files instead of `git add -A`
+- **Don't skip hooks**: Never use `--no-verify` unless explicitly requested
+- **Check for unstaged changes**: Review `git status` output to ensure all intended changes are staged
+
+## Error Handling
+
+If commit fails:
+- Check if there are actually changes to commit
+- Verify you're in the correct directory
+- Check if a commit is already in progress (merge/rebase)
+- Ensure commit message format is valid
+
+## Workflow Integration
+
+This rule works well with:
+- `@generate-karayaml-pr-info` - Generate PR info before creating pull request
+- `@create-karayaml-changelog` - Create a changelog entry for the work
+- After completing a development task
+- Before creating a pull request
+
+## Execution
+
+When this rule is triggered:
+
+1. Navigate to karayaml workspace
+2. Run `git status` to check current changes
+3. Analyze changes and conversation context
+4. Propose commit message following the format above
+5. Execute the commit command with appropriate permissions (git_write)
+6. Confirm successful commit

--- a/.cursor/rules/create-karayaml-changelog.mdc
+++ b/.cursor/rules/create-karayaml-changelog.mdc
@@ -1,0 +1,322 @@
+---
+description: Action rule to create a well-structured changelog document capturing meaningful engineering work, sized proportionally to the feature's impact and complexity.
+globs: []
+alwaysApply: false
+---
+
+# Rule: Create KaraYaml Changelog (action)
+
+Purpose: When invoked, create a comprehensive changelog document in the `_changelog/` directory that captures the essence, context, and impact of recent engineering work. The changelog should be meaningful, well-structured, and appropriately sized based on the scope and impact of the change.
+
+Usage: Invoke explicitly as `@create-karayaml-changelog` after completing meaningful work in a conversation.
+
+References: `@commit-karayaml-changes`, existing changelogs in `_changelog/`
+
+## CRITICAL: Explicit Invocation Only
+
+**DO NOT** create a changelog automatically or proactively. Changelogs must ONLY be created when the user explicitly invokes this rule with `@create-karayaml-changelog`.
+
+Never:
+- Suggest creating a changelog without being asked
+- Create a changelog at the end of a conversation automatically
+- Assume the user wants a changelog created
+- Create a changelog "to be helpful" without explicit request
+
+Always:
+- Wait for explicit `@create-karayaml-changelog` invocation
+- Confirm the request before creating the file
+- Let the user decide when/if a changelog is needed
+
+**This is a user-controlled action, not an automatic process.**
+
+## When to Create a Changelog
+
+Create a changelog when:
+- You've completed a meaningful feature, refactoring, or improvement
+- The work involved multiple files or components
+- The change introduces new commands or significant enhancements
+- The work took significant time/effort (typically 1+ hours)
+- The change has notable impact on karayaml users or functionality
+- You want to preserve the context and rationale for future reference
+
+**Skip changelogs for**:
+- Trivial bug fixes or typo corrections
+- Minor configuration tweaks
+- Work-in-progress or incomplete changes
+- Changes already well-documented in PR descriptions
+
+## Sizing Guidance: Use Your Judgment
+
+**Critical principle**: The changelog length should be **proportional to the feature's complexity and impact**, not artificially constrained or inflated.
+
+### Small Changes (150-300 lines)
+- Single command updates or enhancements
+- Focused bug fixes with clear before/after
+- Minor flag additions
+- Configuration improvements
+- Alias additions
+
+**Example**: Adding aliases for existing commands - straightforward problem, clear solution, limited scope
+
+### Medium Changes (300-600 lines)
+- New command implementations
+- Significant refactoring of core packages
+- Multi-component improvements
+- New filtering or search capabilities
+
+**Example**: Adding filter command with key and app subcommands - new pattern, multiple functions, improved UX
+
+### Large Changes (600-1000+ lines)
+- Major architectural changes
+- Complete rewrites of subsystems
+- New Karabiner-Elements integration features
+- System-wide refactoring with broad impact
+
+**Example**: Complete rewrite of shortcut configuration system, new YAML schema support
+
+**Golden rule**: If you're unsure, start shorter and add detail only where it adds real value. Quality over quantity.
+
+## Changelog Structure
+
+### File Naming
+```
+YYYY-MM-DD-HHMMSS-brief-descriptive-slug.md
+```
+
+Examples:
+- `2025-11-14-180530-filter-command-implementation.md`
+- `2025-11-10-143022-command-aliases.md`
+- `2025-11-05-091545-shortcut-key-validation.md`
+
+**IMPORTANT**: Get the actual current timestamp by running the command `date +"%Y-%m-%d-%H%M%S"` and use that exact output as the prefix for the filename. Do NOT make up or guess the timestamp. Follow with a clear, kebab-case slug describing the change. The timestamp (HHMMSS) ensures automatic chronological sorting when multiple changelogs are created on the same day.
+
+### Required Sections
+
+Every changelog should include:
+
+```markdown
+# [Clear, Descriptive Title]
+
+**Date**: [Month Day, Year]
+
+## Summary
+
+[2-4 sentence overview of what was accomplished and why it matters]
+
+## Problem Statement
+
+[Describe the problem or need that motivated this work]
+
+### Pain Points
+
+[Bullet list of specific issues being addressed]
+
+## Solution
+
+[High-level description of the approach taken]
+
+### Key Components
+
+[Component descriptions, affected packages, new functions]
+
+## Implementation Details
+
+[Technical specifics - code changes, new patterns, key decisions]
+
+## Benefits
+
+[Concrete improvements - UX enhancements, performance, reliability]
+
+## Impact
+
+[Who/what is affected and how - users, developers, workflows]
+
+## Related Work
+
+[Connect to other changelogs, features, or initiatives]
+
+---
+
+**Status**: [Production Ready | In Progress | Experimental]
+**Timeline**: [Duration if relevant]
+```
+
+### Optional Sections (Include When Valuable)
+
+Add these sections only when they provide meaningful value:
+
+- **Breaking Changes**: When CLI flags, commands, or behavior changes
+- **Migration Guide**: When users need to update their workflows
+- **Testing Strategy**: For complex features requiring verification
+- **Performance Characteristics**: When performance is a key concern
+- **Known Limitations**: For incomplete implementations
+- **Future Enhancements**: For planned follow-up work
+- **Code Metrics**: Statistics that tell a story (files changed, LOC, etc.)
+- **Design Decisions**: When trade-offs were significant
+- **Examples/Usage**: When it helps understanding (command examples, outputs)
+
+## Writing Guidelines
+
+### Do:
+- **Start with context**: Why did this work happen?
+- **Focus on value**: What problem does this solve for karayaml users?
+- **Use concrete examples**: Show before/after commands, outputs
+- **Include numbers**: Metrics, file counts, performance improvements
+- **Explain decisions**: Why this approach vs alternatives?
+- **Write for future you**: Capture the thinking, not just the what
+- **Link to related work**: Connect the dots with other changes
+- **Use formatting**: Code blocks, tables, bullet lists for readability
+- **Show user impact**: How does this improve the user experience?
+
+### Don't:
+- **Over-explain the obvious**: Assume the reader is technical
+- **Include every detail**: Focus on what matters
+- **Write generic summaries**: Be specific to karayaml's functionality
+- **Skip the "why"**: Context is critical for future understanding
+- **Ignore trade-offs**: Document decisions and their rationale
+- **Use jargon without context**: Define terms that may be unclear
+
+## Tone and Style
+
+- **Informative, not promotional**: Focus on facts and impact
+- **Technical but accessible**: Balance depth with clarity
+- **Professional but human**: You can say "this was tricky" or "users were frustrated"
+- **Present tense for descriptions**: "The command now does X"
+- **Past tense for actions**: "We implemented Y"
+
+## Quality Checklist
+
+Before finalizing a changelog:
+
+- [ ] Title clearly describes the change
+- [ ] Summary captures essence in 2-4 sentences
+- [ ] Problem statement explains why work was needed
+- [ ] Solution section describes the approach
+- [ ] Implementation details are technical but focused
+- [ ] Benefits are concrete and measurable
+- [ ] Code/command examples are actual examples, not pseudocode
+- [ ] Related work connects this to other changes
+- [ ] Length is proportional to scope and impact
+- [ ] No sensitive information (credentials, private URLs, etc.)
+
+## Proportionality Examples
+
+### Appropriately Sized
+
+**Small feature** (200 lines): 
+- Problem: 1 paragraph
+- Solution: 1-2 paragraphs + key code snippet or command example
+- Benefits: 3-5 bullets
+- Impact: 1 paragraph
+
+**Medium feature** (500 lines):
+- Problem: 2-3 paragraphs with pain points
+- Solution: Architecture description + component details
+- Implementation: 3-4 key changes with examples
+- Benefits: Categorized list with user impact
+- Impact: User experience + workflow improvements
+
+**Large feature** (900 lines):
+- Problem: Comprehensive context with user scenarios
+- Solution: Full architecture with component breakdown
+- Implementation: Detailed technical sections per component
+- Benefits: Quantitative and qualitative analysis
+- Testing: Strategy and verification steps
+- Impact: Multi-dimensional (users, workflows, integrations)
+
+### Anti-patterns
+
+- **Over-detailed small change**: 800-line changelog for a simple alias addition
+- **Under-documented major change**: 150-line changelog for complete command system rewrite
+- **Kitchen sink**: Including every file touched, every line changed
+- **Too abstract**: Generic descriptions without concrete command examples
+
+## KaraYaml-Specific Guidelines
+
+### Scope Areas to Cover
+
+When writing changelogs for karayaml, consider these areas:
+
+**Commands**:
+- Which commands were added, modified, or removed?
+- How do command behaviors change?
+- What new flags or options are available?
+- Were aliases added?
+
+**Shortcut Management**:
+- How does shortcut loading, listing, or searching change?
+- Are new filtering or matching modes available?
+- Is the YAML parsing improved?
+
+**Karabiner Integration**:
+- Does this affect Karabiner-Elements configuration generation?
+- Are new key mappings or modifiers supported?
+- Does the reload behavior change?
+
+**User Workflows**:
+- How does this improve daily shortcut management?
+- What time does it save?
+- What frustrations does it eliminate?
+
+**Package Architecture**:
+- Which packages were affected? (`internal/shortcuts`, `internal/karabinerconfig`, `cmd/karayaml/root`, etc.)
+- What new abstractions or patterns were introduced?
+- How does this affect code organization?
+
+**Dependencies & Build**:
+- Were dependencies updated?
+- Did the build system change?
+- Are there new installation requirements?
+
+### Command Example Format
+
+When showing command examples, use this format:
+
+```bash
+# Before
+$ karayaml search auth
+Error: unknown command "search" for "karayaml"
+
+# After
+$ karayaml search auth
+Yeah, I found one match: key '9' is mapped to '/Users/me/Applications/Auth0.app'
+```
+
+## Automation Notes
+
+When creating the changelog:
+1. **Get current timestamp**: Run `date +"%Y-%m-%d-%H%M%S"` to get the actual current date and time for the filename
+2. **Analyze the conversation**: Extract key decisions, changes, outcomes
+3. **Assess scope**: Count files, packages, commands affected
+4. **Determine sections**: Include only relevant sections
+5. **Size appropriately**: Match detail level to impact
+6. **Write the file**: Create in `_changelog/YYYY-MM/` (year-month directory) with proper naming using the timestamp from step 1
+7. **Confirm creation**: Provide file path and next steps
+
+## Example Invocations
+
+```
+"We just completed the filter command implementation. @create-karayaml-changelog"
+
+"I've finished adding aliases for find and list commands. 
+@create-karayaml-changelog"
+
+"The new shortcut filtering system is done and tested. 
+@create-karayaml-changelog - this improves discoverability significantly"
+```
+
+## Remember
+
+**Changelogs are living documentation** that helps future developers (including you) understand:
+- What changed in karayaml
+- Why it changed
+- How it was implemented
+- What the user impact was
+
+Write for the person who will need to understand this feature or debug an issue at 2am in six months. Give them the context they need - no more, no less.
+
+**When in doubt**: Start with the required sections, keep it focused, and add detail only where it truly helps understanding. A clear, concise 300-line changelog is better than a rambling 1000-line document.
+
+---
+
+*"Documentation is a love letter to your future self."* - Damian Conway

--- a/.cursor/rules/generate-karayaml-pr-info.mdc
+++ b/.cursor/rules/generate-karayaml-pr-info.mdc
@@ -1,0 +1,179 @@
+---
+description: Generate a PR title and a Markdown PR description as exactly two copyable code blocks (ask-only). Conventional Commit prefix + scope from file paths. No repo edits.
+globs:
+alwaysApply: false
+---
+
+# Rule: Pull Request Title and Description for KaraYaml (ask-only)
+
+Purpose: When asked to write a PR title and PR description for karayaml, respond with exactly two copyable code blocks — first the title, then the description — without making any repository changes.
+
+This rule is designed for ask mode only. Do not modify files, run commands, or propose edits. Output only the two fenced code blocks described below.
+
+Usage: In Ask mode, invoke explicitly as `@generate-karayaml-pr-info` or `@pr-info`.
+
+## How to respond (strict)
+1) First block: PR Title
+   - Fenced code block with language: `text`
+   - Single line only
+   - Prefix using Conventional Commits: one of `feat`, `fix`, `refactor`, `docs`, `test`, `perf`, `ci`, `build`, `chore`, `revert`
+   - Scope is required and must be component-aware, using a token derived from changed files (examples below)
+   - Imperative mood, concise, ≤ 72 characters after the prefix
+   - No trailing period
+
+2) Second block: PR Description
+   - Fenced code block with language: `markdown`
+   - Use the following sections when applicable. Omit any that are not relevant.
+     - "Summary": 1-3 sentences describing what this PR does in plain language
+     - "Context": Why this change is needed (problem, bug, or goal)
+     - "Changes": Bullet list of key changes; group by area if helpful
+     - "Implementation notes": Important design decisions or trade-offs
+     - "Breaking changes": Clearly call out any breaking behavior and migration steps
+     - "Test plan": How this was verified (tests, manual steps, screenshots/links)
+     - "Risks": Known risks or rollback plan
+     - "Checklist": Markdown checkboxes for docs, tests, backward compatibility
+     - Optionally include issue links like `Closes #123` when known
+
+## Title format (exactly)
+
+```text
+<prefix>(<scope>): <concise, imperative title>
+```
+
+- Examples of valid scopes: `cmd`, `cmd/root`, `internal/shortcuts`, `internal/karabinerconfig`, `internal/defaulteditor`, `internal/upgrade`, `site`, `build`, `release`, `deps`, `docs`, `readme`, `repo`.
+
+## How to infer the title prefix
+- `feat`: Adds a new capability, command, flag, alias, or config that users can opt into
+- `fix`: Corrects a bug or regression
+- `refactor`: Code restructuring without changing externally visible behavior
+- `docs`: Documentation-only changes (`*.md`, docs)
+- `test`: Tests only
+- `perf`: Performance improvements
+- `ci`: CI pipeline/config changes
+- `build`: Build system or dependency changes (Makefile, GoReleaser, go.mod)
+- `chore`: Routine maintenance (formatting, small cleanups) not covered above
+- `revert`: Reverts a previous commit/PR
+
+Prefer `feat` vs `refactor` based on whether user-facing capability is introduced. Prefer `fix` when the primary intent is to resolve a defect, even if some refactoring was required.
+
+## Scope heuristics (karayaml repository)
+Determine the `<scope>` from the changed files. Use the most impacted area by lines changed; if multiple, see multi-area guidance below.
+
+- Core Commands
+  - `cmd/karayaml/root/*.go` -> `cmd` or `cmd/<specific-command>` (e.g., `cmd/find`, `cmd/filter`)
+  - If multiple commands affected -> `cmd`
+
+- Internal Packages
+  - `internal/shortcuts/**` -> `internal/shortcuts`
+  - `internal/karabinerconfig/**` -> `internal/karabinerconfig`
+  - `internal/defaulteditor/**` -> `internal/defaulteditor`
+  - `internal/upgrade/**` -> `internal/upgrade`
+  - Multiple internal packages -> `internal`
+
+- Site (Landing Page)
+  - `site/**` -> `site`
+  - `site/src/components/**` -> `site` (unless very specific)
+
+- Build and Configuration
+  - `Makefile` or `scripts/` -> `build`
+  - `.goreleaser.yaml` -> `release`
+  - `go.mod`, `go.sum` -> `deps`
+  - `.gitignore`, `.github/**` -> `repo`
+
+- Documentation
+  - `README.md` (root) -> `readme`
+  - `docs/**` or other markdown files -> `docs`
+
+### Multi-area changes
+- If changes span multiple internal packages, use `internal`
+- If changes span commands and internal packages, use the primary area or omit scope
+- If changes are broadly cross-cutting (>=3 unrelated areas), use `repo`
+
+## Inputs to use when generating
+- The full diff and edit history from this session
+- Changed files and their paths to infer scope using the rules above
+- Commit messages, branch name, or linked issues if available
+
+If context is insufficient to infer details, choose the best effort scope from filenames and touched areas. Do not ask questions; still produce both blocks.
+
+## Output blocks (exactly two, nothing else)
+
+```text
+<prefix>(<scope>): <concise, imperative title>
+```
+
+```markdown
+## Summary
+<1-3 sentences>
+
+## Context
+<why this change was needed>
+
+## Changes
+- <key change 1>
+- <key change 2>
+- <key change 3>
+
+## Implementation notes
+- <notable decision or trade-off>
+
+## Breaking changes
+- <explicitly list or state "None">
+
+## Test plan
+- <how verified>
+
+## Risks
+- <risks and rollback>
+
+## Checklist
+- [ ] Docs updated (if needed)
+- [ ] Tests added/updated (if needed)
+- [ ] Backward compatible
+
+<!-- Optionally: Closes #123 -->
+```
+
+## Example Output
+
+For a change that adds a filter command with key and app subcommands:
+
+```text
+feat(cmd): add filter command with filter-key and filter-app subcommands
+```
+
+```markdown
+## Summary
+Adds a new `filter` parent command with `filter-key` and `filter-app` subcommands for filtering shortcuts by key or app/file path. Supports fuzzy substring matching by default and exact matching via `--exact` flag.
+
+## Context
+Users needed a way to narrow down their shortcut list by either the mapped key or the application path. The existing `find` command only searches by app name. A dedicated filter command provides more targeted lookup capabilities.
+
+## Changes
+- Add `filter` parent command in `cmd/karayaml/root/filter.go`
+- Add `filter-key` subcommand with `--exact` flag in `cmd/karayaml/root/filter_key.go`
+- Add `filter-app` subcommand with `--exact` flag in `cmd/karayaml/root/filter_app.go`
+- Add `FilterByKey()` and `FilterByApp()` helper functions in `internal/shortcuts/list.go`
+- Register `filter` command in root command
+
+## Implementation notes
+- Fuzzy matching uses case-insensitive substring containment, consistent with the existing `find` command behavior
+- Exact matching uses case-insensitive equality
+- Both subcommands reuse the existing `PrintMatches()` display function for consistent output formatting
+
+## Breaking changes
+- None
+
+## Test plan
+- Built and tested locally with `go build ./...`
+- Verified `filter filter-key` and `filter filter-app` with both fuzzy and exact modes
+- Verified existing commands are unaffected
+
+## Risks
+- Low risk: New commands only, no changes to existing behavior
+
+## Checklist
+- [ ] Docs updated (if needed)
+- [ ] Tests added/updated (if needed)
+- [x] Backward compatible
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-

--- a/_changelog/2026-02/2026-02-15-060549-command-aliases-and-filter-command.md
+++ b/_changelog/2026-02/2026-02-15-060549-command-aliases-and-filter-command.md
@@ -1,0 +1,73 @@
+# Command Aliases and Filter Command
+
+**Date**: February 15, 2026
+
+## Summary
+
+Added `search` as an alias for the `find` command, `ls` as an alias for the `list` command, and introduced a new `filter` parent command with `filter-key` and `filter-app` subcommands. The filter subcommands support both fuzzy substring matching (default) and exact matching via an `--exact` flag. This improves CLI discoverability and gives users more targeted ways to look up their shortcuts.
+
+## Problem Statement
+
+Users were trying natural command names that didn't exist -- `karayaml search auth` and `karayaml ls` both returned "unknown command" errors. Additionally, the existing `find` command only searches by app/file name. There was no way to filter shortcuts by their mapped key (e.g., "show me everything mapped to keys starting with `f`").
+
+### Pain Points
+
+- `search` is a natural synonym for `find` but was not recognized
+- `ls` is a universal shorthand for listing but was not recognized
+- No way to filter shortcuts by key -- only by app name via `find`
+- No way to do exact-match lookups (e.g., find only the shortcut mapped to exactly key `f`, not `f1`, `f2`, etc.)
+
+## Solution
+
+Leveraged Cobra's built-in `Aliases` field for the two alias additions -- zero friction, no additional wiring needed. For filtering, introduced a `filter` parent command with two subcommands (`filter-key` and `filter-app`), each accepting a positional query argument and an `--exact` flag.
+
+### Key Components
+
+- **`cmd/karayaml/root/find.go`** -- Added `Aliases: []string{"search"}`
+- **`cmd/karayaml/root/list.go`** -- Added `Aliases: []string{"ls"}`
+- **`cmd/karayaml/root/filter.go`** -- New parent command that registers `filter-key` and `filter-app`
+- **`cmd/karayaml/root/filter_key.go`** -- Filters shortcuts by key with `--exact` flag
+- **`cmd/karayaml/root/filter_app.go`** -- Filters shortcuts by app/file path with `--exact` flag
+- **`internal/shortcuts/list.go`** -- New `FilterByKey()` and `FilterByApp()` functions
+- **`cmd/karayaml/root.go`** -- Registered `root.Filter` in the root command
+
+## Implementation Details
+
+**Aliases** use Cobra's native `Aliases` field, which automatically registers the alias and shows it in help output:
+
+```go
+var Find = &cobra.Command{
+    Use:     "find <query>",
+    Aliases: []string{"search"},
+    // ...
+}
+```
+
+**Filter functions** follow the same pattern as the existing `Find()` function. Both `FilterByKey` and `FilterByApp` accept a `query` string and an `exact` bool. When `exact` is false, they do case-insensitive substring matching (`strings.Contains`). When true, they do case-insensitive equality (`==`).
+
+**Filter commands** each maintain their own `--exact` flag via a package-level bool variable, registered in an `init()` function. Both reuse the existing `PrintMatches()` function for consistent table output.
+
+## Benefits
+
+- Users can now type `karayaml search` or `karayaml ls` as they'd naturally expect
+- Shortcuts can be filtered by key, which was previously impossible
+- Exact matching enables precise lookups when the fuzzy default is too broad
+- Consistent UX: filter output uses the same table format as `find`
+- No breaking changes to existing commands
+
+## Impact
+
+**Users**: Two fewer "unknown command" errors for common aliases. New filtering capability for power users managing many shortcuts.
+
+**Developers**: Clean pattern for adding future filter dimensions (e.g., filter by key category). The `FilterByKey`/`FilterByApp` functions are simple and composable.
+
+**Files changed**: 5 modified, 3 new (63 insertions across modified files + ~120 lines in new files).
+
+## Related Work
+
+This is the first feature addition to karayaml's CLI command set beyond the original `find`, `list`, `map`, `edit`, `init`, `reload`, and `upgrade` commands. The `filter` command pattern could be extended in the future to support filtering by key category (function keys, numbers, letters).
+
+---
+
+**Status**: Production Ready
+**Timeline**: Single session

--- a/cmd/karayaml/root.go
+++ b/cmd/karayaml/root.go
@@ -43,6 +43,7 @@ func init() {
 		root.Reload,
 		root.Find,
 		root.List,
+		root.Filter,
 		root.Upgrade,
 		root.Version,
 	)

--- a/cmd/karayaml/root/filter.go
+++ b/cmd/karayaml/root/filter.go
@@ -1,0 +1,14 @@
+package root
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var Filter = &cobra.Command{
+	Use:   "filter",
+	Short: "filter shortcuts by key or app/file",
+}
+
+func init() {
+	Filter.AddCommand(FilterKey, FilterApp)
+}

--- a/cmd/karayaml/root/filter_app.go
+++ b/cmd/karayaml/root/filter_app.go
@@ -1,0 +1,35 @@
+package root
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/swarupdonepudi/karayaml/internal/shortcuts"
+)
+
+var filterAppExact bool
+
+var FilterApp = &cobra.Command{
+	Use:   "filter-app <query>",
+	Short: "filter shortcuts by app/file path (fuzzy substring match by default, use --exact for exact match)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		query := args[0]
+		matches, err := shortcuts.FilterByApp(query, filterAppExact)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println("")
+		if len(matches) == 0 {
+			fmt.Println("No matches found")
+		} else {
+			shortcuts.PrintMatches(matches)
+		}
+	},
+}
+
+func init() {
+	FilterApp.Flags().BoolVar(&filterAppExact, "exact", false, "require exact match instead of substring match")
+}

--- a/cmd/karayaml/root/filter_key.go
+++ b/cmd/karayaml/root/filter_key.go
@@ -1,0 +1,35 @@
+package root
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/swarupdonepudi/karayaml/internal/shortcuts"
+)
+
+var filterKeyExact bool
+
+var FilterKey = &cobra.Command{
+	Use:   "filter-key <query>",
+	Short: "filter shortcuts by key (fuzzy substring match by default, use --exact for exact match)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		query := args[0]
+		matches, err := shortcuts.FilterByKey(query, filterKeyExact)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println("")
+		if len(matches) == 0 {
+			fmt.Println("No matches found")
+		} else {
+			shortcuts.PrintMatches(matches)
+		}
+	},
+}
+
+func init() {
+	FilterKey.Flags().BoolVar(&filterKeyExact, "exact", false, "require exact match instead of substring match")
+}

--- a/cmd/karayaml/root/find.go
+++ b/cmd/karayaml/root/find.go
@@ -8,8 +8,9 @@ import (
 )
 
 var Find = &cobra.Command{
-	Use:   "find <query>",
-	Short: "search ~/.kara.yaml for apps whose name contains the query (case-insensitive)",
+	Use:     "find <query>",
+	Aliases: []string{"search"},
+	Short:   "search ~/.kara.yaml for apps whose name contains the query (case-insensitive)",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		query := args[0]

--- a/cmd/karayaml/root/list.go
+++ b/cmd/karayaml/root/list.go
@@ -8,8 +8,9 @@ import (
 )
 
 var List = &cobra.Command{
-	Use:   "list",
-	Short: "list shortcuts to open apps",
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "list shortcuts to open apps",
 	Run:   listHandler,
 }
 

--- a/internal/shortcuts/list.go
+++ b/internal/shortcuts/list.go
@@ -131,6 +131,62 @@ func Find(query string) ([]*FileOpenShortcut, error) {
 	return matches, nil
 }
 
+// FilterByKey returns shortcuts whose Key matches the query.
+// If exact is true, only exact (case-insensitive) matches are returned.
+// Otherwise, keys that contain the query as a substring are returned.
+func FilterByKey(query string, exact bool) ([]*FileOpenShortcut, error) {
+	list, err := List()
+	if err != nil {
+		return nil, err
+	}
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return []*FileOpenShortcut{}, nil
+	}
+	matches := make([]*FileOpenShortcut, 0)
+	for _, s := range list {
+		k := strings.ToLower(string(s.Key))
+		if exact {
+			if k == q {
+				matches = append(matches, s)
+			}
+		} else {
+			if strings.Contains(k, q) {
+				matches = append(matches, s)
+			}
+		}
+	}
+	return matches, nil
+}
+
+// FilterByApp returns shortcuts whose File path matches the query.
+// If exact is true, only exact (case-insensitive) matches are returned.
+// Otherwise, files that contain the query as a substring are returned.
+func FilterByApp(query string, exact bool) ([]*FileOpenShortcut, error) {
+	list, err := List()
+	if err != nil {
+		return nil, err
+	}
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return []*FileOpenShortcut{}, nil
+	}
+	matches := make([]*FileOpenShortcut, 0)
+	for _, s := range list {
+		f := strings.ToLower(s.File)
+		if exact {
+			if f == q {
+				matches = append(matches, s)
+			}
+		} else {
+			if strings.Contains(f, q) {
+				matches = append(matches, s)
+			}
+		}
+	}
+	return matches, nil
+}
+
 // FormatSingleMatchMessage returns a friendly sentence for a single match.
 func FormatSingleMatchMessage(s *FileOpenShortcut) string {
 	if s == nil {


### PR DESCRIPTION
## Summary
Adds `search` and `ls` as aliases for `find` and `list` respectively, and introduces a new `filter` parent command with `filter-key` and `filter-app` subcommands. Both filter subcommands support fuzzy substring matching by default and exact matching via `--exact` flag.

## Context
Users were hitting "unknown command" errors when trying natural synonyms like `karayaml search` and `karayaml ls`. Additionally, the existing `find` command only searches by app/file name -- there was no way to filter shortcuts by their mapped key, or to perform exact-match lookups.

## Changes

### Aliases
- Add `search` as alias for `find` command in `cmd/karayaml/root/find.go`
- Add `ls` as alias for `list` command in `cmd/karayaml/root/list.go`

### Filter command
- Add `filter` parent command in `cmd/karayaml/root/filter.go`
- Add `filter-key` subcommand with `--exact` flag in `cmd/karayaml/root/filter_key.go`
- Add `filter-app` subcommand with `--exact` flag in `cmd/karayaml/root/filter_app.go`
- Add `FilterByKey()` and `FilterByApp()` functions in `internal/shortcuts/list.go`
- Register `filter` command in root command (`cmd/karayaml/root.go`)

### Tooling
- Add Cursor rules for commits, changelogs, and PR info generation
- Add initial changelog entry

## Implementation notes
- Aliases use Cobra's native `Aliases` field -- no additional wiring needed
- Fuzzy matching uses case-insensitive `strings.Contains`, consistent with the existing `find` behavior
- Exact matching uses case-insensitive string equality
- Both filter subcommands reuse the existing `PrintMatches()` display function for consistent table output

## Breaking changes
- None

## Test plan
- Built successfully with `go build ./...`
- Verified `karayaml search --help` and `karayaml ls --help` show alias registration
- Verified `karayaml filter --help` lists both subcommands
- Verified `karayaml filter filter-key --help` shows `--exact` flag
- Verified existing `find` and `list` commands are unaffected

## Risks
- Low risk: All changes are additive -- new aliases and new commands only, no modifications to existing behavior

## Checklist
- [ ] Docs updated (if needed)
- [ ] Tests added/updated (if needed)
- [x] Backward compatible